### PR TITLE
updates and bug fixes

### DIFF
--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -7,6 +7,7 @@ ct.Spelltarget              = nil           -- The unit on which a spell shall b
 ct.SpellUniqueIdentifier    = 0             -- Every spell will have this value (like a primary key in a database)
 ct.CurrentUniqueIdentifier  = nil           -- This is the primary key of the spell that is currently being casted
 ct.SpellIsInstant           = true
+ct.CurrentSpell             = nil
 
 -- GLOBAL SETTINGS
 
@@ -16,7 +17,7 @@ ct.ReTargetHighestUnit      = false
 ct.ReTargetLowestUnit       = false
 
 -- Combat behavior
-ct.AllowOutOfCombatRoutine  = false
+ct.AllowOutOfCombatRoutine  = true
 
 -- Interrupt behavior
 ct.EnableInterrupt          = true
@@ -38,20 +39,20 @@ function ct.StartUp()
     frame:RegisterEvent("PLAYER_REGEN_ENABLED")
     frame:RegisterEvent("UNIT_SPELLCAST_START")
     frame:RegisterEvent("UNIT_SPELLCAST_SENT")
-    frame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
 
     -- This handles the removing of spells from the spellqueue
+    -- TODO: fix user cast removing spells from queue
     local function spellDetectionHandler()
       -- for instant spells
       if ct.SpellIsInstant and ct.SpellQueue[1] ~= nil
       and ct.CurrentUniqueIdentifier == ct.SpellQueue[1].key then
-        ct.DeQueueSpell(ct.SpellQueue[1].spell)
+        ct.DeQueueSpell(ct.CurrentSpell)
       end
 
       -- for casted spells
       if not ct.IsCasting(ct.player) and ct.CastedPercent(ct.player) ~= nil
       and ct.SpellQueue[1] ~= nil and ct.CurrentUniqueIdentifier == ct.SpellQueue[1].key then
-        ct.DeQueueSpell(ct.SpellQueue[1].spell)
+        ct.DeQueueSpell(ct.CurrentSpell)
         -- Spell History
         -- maximum lenght of spell history is 10 entries
         if getn(ct.SpellHistory) > 10 then
@@ -77,6 +78,7 @@ function ct.StartUp()
       end
       if event == "UNIT_SPELLCAST_SENT" and arg1 == "player" and getn(ct.SpellQueue) ~= 0 then
         ct.CurrentUniqueIdentifier = ct.SpellQueue[1].key
+        ct.CurrentSpell = ct.GetSpellID(arg2)
       end
     end
 

--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -6,7 +6,6 @@ ct.Target                   = nil           -- The unit which the player is targ
 ct.Spelltarget              = nil           -- The unit on which a spell shall be casted
 ct.SpellUniqueIdentifier    = 0             -- Every spell will have this value (like a primary key in a database)
 ct.CurrentUniqueIdentifier  = nil           -- This is the primary key of the spell that is currently being casted
-ct.SpellIsInstant           = true
 ct.CurrentSpell             = nil
 
 -- GLOBAL SETTINGS
@@ -26,7 +25,7 @@ ct.InterruptMinPercent      = 20
 ct.InterruptMaxPercent      = 80
 
 -- Cast Logic Settings
-ct.CastDelay                = 150           -- The lower, the more delay will be between each spellcast
+ct.CastDelay                = 200           -- The lower, the more delay will be between each spellcast
 ct.CastAngle                =  90           -- Facing angle for casted spells
 ct.ConeAngle                =  45           -- Facing angle for cone logic
 
@@ -38,18 +37,9 @@ function ct.StartUp()
 
     frame:RegisterEvent("PLAYER_REGEN_ENABLED")
     frame:RegisterEvent("UNIT_SPELLCAST_START")
-    frame:RegisterEvent("UNIT_SPELLCAST_SENT")
 
-    -- This handles the removing of spells from the spellqueue
-    -- TODO: fix user cast removing spells from queue
+    -- This handles the removing of casted spells from the spellqueue
     local function spellDetectionHandler()
-      -- for instant spells
-      if ct.SpellIsInstant and ct.SpellQueue[1] ~= nil
-      and ct.CurrentUniqueIdentifier == ct.SpellQueue[1].key then
-        ct.DeQueueSpell(ct.CurrentSpell)
-      end
-
-      -- for casted spells
       if not ct.IsCasting(ct.player) and ct.CastedPercent(ct.player) ~= nil
       and ct.SpellQueue[1] ~= nil and ct.CurrentUniqueIdentifier == ct.SpellQueue[1].key then
         ct.DeQueueSpell(ct.CurrentSpell)
@@ -63,22 +53,16 @@ function ct.StartUp()
         local Entry = {spell = arg5, time = GetTime()}
         table.insert(ct.SpellHistory, Entry)
       end
-
-      ct.SpellIsInstant = true
     end
 
     local function eventHandler(self, event, arg1, arg2, arg3, arg4, arg5, arg6)
       if event == "UNIT_SPELLCAST_START" and arg1 == "player" and getn(ct.SpellQueue) ~= 0 then
         ct.CurrentUniqueIdentifier = ct.SpellQueue[1].key
-        ct.SpellIsInstant = false
+        ct.CurrentSpell = ct.GetSpellID(arg2)
       end
       if event == "PLAYER_REGEN_ENABLED" then
         -- player left any combat action so the queue will be cleaned up
         ct.CleanUpQueue()
-      end
-      if event == "UNIT_SPELLCAST_SENT" and arg1 == "player" and getn(ct.SpellQueue) ~= 0 then
-        ct.CurrentUniqueIdentifier = ct.SpellQueue[1].key
-        ct.CurrentSpell = ct.GetSpellID(arg2)
       end
     end
 

--- a/Core/RotationEngine.lua
+++ b/Core/RotationEngine.lua
@@ -55,22 +55,34 @@ end
 
 -- Handles Interrupting
 -- this can currently only interrupt the current target
--- TODO: add setting to interrupt any unit
 function ct.InterruptEngine()
   local Unit = nil
-  if UnitGUID("target") ~= nil then
-    Unit = GetObjectWithGUID(UnitGUID("target"))
-  end
-  if Unit ~= nil and select(9, UnitCastingInfo(Unit)) == false and ct.UnitIsHostile(Unit) then
-    local PercentCasted = ct.CastedPercent(Unit)
-    if ct.InterruptMinPercent < PercentCasted
-    and PercentCasted < ct.InterruptMaxPercent and ct.Interrupt ~= nil then
-      ct.Interrupt(Unit)
+  -- interrupt any unit
+  if ct.InterruptAnyUnit then
+    for i = 0, getn(ct.enemys) do
+      Unit = ct.enemys[i][1]
+      if Unit ~= nil and select(9, UnitCastingInfo(Unit)) == false and ct.UnitIsHostile(Unit) then
+        local PercentCasted = ct.CastedPercent(Unit)
+        if ct.InterruptMinPercent < PercentCasted
+        and PercentCasted < ct.InterruptMaxPercent and ct.Interrupt ~= nil then
+          ct.Interrupt(Unit)
+        end
+      end
+    end
+    -- interrupt target
+  else
+    if UnitGUID("target") ~= nil then
+      Unit = GetObjectWithGUID(UnitGUID("target"))
+    end
+    if Unit ~= nil and select(9, UnitCastingInfo(Unit)) == false and ct.UnitIsHostile(Unit) then
+      local PercentCasted = ct.CastedPercent(Unit)
+      if ct.InterruptMinPercent < PercentCasted
+      and PercentCasted < ct.InterruptMaxPercent and ct.Interrupt ~= nil then
+        ct.Interrupt(Unit)
+      end
     end
   end
 end
-
--- TODO: add function to predict incoming healing and absorbs on a unit
 
 -- Handles Disspelling
 function ct.DisspellEngine()

--- a/Core/SpellManager.lua
+++ b/Core/SpellManager.lua
@@ -1,10 +1,9 @@
 ct.SpellQueue = {}
 ct.SpellHistory = {}
 
--- pulses the SpellQueue and tries to cast from it
--- spells will be casted on the current target by default
-
--- TODO: fix spells double casting becasuse they were not removed quick enough
+-- The Spell Queue does only contain casted or channeled spells
+-- However, the PulseQueue function also pulses the Rotation file (which also contains instant casts)
+-- Unless there is some real necessity Instant casts shall always be casted by the rotation file (with CastSpellByID)
 function ct.PulseQueue()
 
   -- pulse appropriate rotation if spellQueue is empty

--- a/Core/SpellManager.lua
+++ b/Core/SpellManager.lua
@@ -25,6 +25,11 @@ function ct.PulseQueue()
     if (not ct.UnitIsMoving(ct.player) or ct.CanCastWhileMoving(SpellID))
     and not ct.IsCasting(ct.player) and UnitGUID(ct.SpellTarget) ~= nil then
       CastSpellByID(SpellID, ct.SpellTarget)
+
+      -- instantly remove the spell if it is an instant cast
+      if select(4, GetSpellInfo(SpellID)) == 0 then
+        ct.DeQueueSpell(SpellID)
+      end
     end
   end
 end

--- a/Rotations/Paladin - Protection.lua
+++ b/Rotations/Paladin - Protection.lua
@@ -25,32 +25,32 @@ function ct.PaladinProtection()
     -- COOLDOWNS
     -- Avenging Wrath (Use on Cooldown)
     if ct.CanCast(31884) then
-      return ct.AddSpellToQueue(31884)
+      return CastSpellByID(31884)
     end
 
     -- Guardian of the Ancient Kings (use when below 30%)
     if ct.CanCast(86659) and UnitHealth(ct.player) <= MaxHealth * 0.3 then
-      return ct.AddSpellToQueue(86659)
+      return CastSpellByID(86659)
     end
 
     -- Ardent Defender (use when below 20%)
     if ct.CanCast(31850) and UnitHealth(ct.player) <= MaxHealth * 0.2 then
-      return ct.AddSpellToQueue(31850, ct.player)
+      return CastSpellByID(31850)
     end
 
     -- Lay on Hands (use when player or lowest raid member is below 15%)
     if ct.CanCast(633) and UnitHealth(ct.player) <= MaxHealth * 0.15 then
-      return ct.AddSpellToQueue(633)
+      return CastSpellByID(633)
     end
 
     if ct.CanCast(633) and LowestFriend ~= nil
     and UnitHealth(LowestFriend) <= UnitHealthMax(LowestFriend) * 0.15 then
-      return ct.AddSpellToQueue(633, LowestFriend)
+      return CastSpellByID(633, LowestFriend)
     end
 
     -- Eye of Tyr (Use when 3 enemys are within 8 yards)
     if getn(ct.GetUnitsInRadius(ct.player, ct.enemys, 8)) >= 3 and ct.CanCast(209202) then
-      return ct.AddSpellToQueue(209202)
+      return CastSpellByID(209202)
     end
 
     -- Divine Shield (do not use yet)
@@ -65,9 +65,9 @@ function ct.PaladinProtection()
     if ct.UnitIsHostile(ct.Target) and ct.CanCast(53600, ct.Target)
     and not ct.UnitHasAura(53600) and ct.IsFacing(ct.Target, ct.CastAngle) then
       if select(1, GetSpellCharges(53600)) > 1 then
-        return ct.AddSpellToQueue(53600)
+        return CastSpellByID(53600)
       elseif UnitHealth(ct.player) <= MaxHealth * 0.4 then
-        return ct.AddSpellToQueue(53600)
+        return CastSpellByID(53600)
       end
     end
 
@@ -75,7 +75,7 @@ function ct.PaladinProtection()
     -- use when below 50% health
     if ct.CanCast(184092) and UnitHealth(ct.player) <= MaxHealth * 0.5
     and (ct.GetPreviousSpell() ~= 184092 or ct.GetTimeSinceLastSpell() >= 500) then
-      return ct.AddSpellToQueue(184092)
+      return CastSpellByID(184092)
     end
 
     -- Flash of Light (use when below 30% health)
@@ -90,31 +90,31 @@ function ct.PaladinProtection()
       -- Consecration (when not moving)
       if ct.UnitIsHostile(ct.Target) and not ct.UnitIsMoving(ct.player)
       and ct.CanCast(26573) and ct.IsInRange(ct.player, ct.Target, 8) then
-        return ct.AddSpellToQueue(26573)
+        return CastSpellByID(26573)
       end
 
       -- Avenger's Shield
       if ct.UnitIsHostile(ct.Target) and ct.IsInLOS(ct.Target)
       and ct.CanCast(31935, ct.Target) and ct.IsFacing(ct.Target, ct.CastAngle) then
-        return ct.AddSpellToQueue(31935)
+        return CastSpellByID(31935)
       end
 
       -- Judgment
       if ct.UnitIsHostile(ct.Target) and ct.IsInLOS(ct.Target)
       and ct.CanCast(20271, ct.Target) and ct.IsFacing(ct.Target, ct.CastAngle) then
-        return ct.AddSpellToQueue(20271)
+        return CastSpellByID(20271)
       end
 
       -- Blessed Hammer (or Hammer of the Righteous)
       if IsSpellKnown(204019) then
         if ct.UnitIsHostile(ct.Target) and ct.CanCast(204019)
         and ct.IsInRange(ct.player, ct.Target, 8) then
-          return ct.AddSpellToQueue(204019)
+          return CastSpellByID(204019)
         end
       elseif IsSpellKnown(53595) then
         if ct.UnitIsHostile(ct.Target) and ct.CanCast(53595)
         and ct.IsInRange(ct.player, ct.Target, 8) then
-          return ct.AddSpellToQueue(53595)
+          return CastSpellByID(53595)
         end
       end
 
@@ -124,19 +124,19 @@ function ct.PaladinProtection()
       -- Judgement
       if ct.UnitIsHostile(ct.Target) and ct.IsInLOS(ct.Target)
       and ct.CanCast(20271, ct.Target) and ct.IsFacing(ct.Target, ct.CastAngle) then
-        return ct.AddSpellToQueue(20271)
+        return CastSpellByID(20271)
       end
 
       -- Consecration (when not moving)
       if ct.UnitIsHostile(ct.Target) and not ct.UnitIsMoving(ct.player)
       and ct.CanCast(26573) and ct.IsInRange(ct.player, ct.Target, 8) then
-        return ct.AddSpellToQueue(26573)
+        return CastSpellByID(26573)
       end
 
       -- Avenger's Shield
       if ct.UnitIsHostile(ct.Target) and ct.IsInLOS(ct.Target)
       and ct.CanCast(31935, ct.Target) and ct.IsFacing(ct.Target, ct.CastAngle) then
-        return ct.AddSpellToQueue(31935)
+        return CastSpellByID(31935)
       end
 
       -- Blessed Hammer
@@ -144,7 +144,7 @@ function ct.PaladinProtection()
       if IsSpellKnown(204019) and ct.UnitIsHostile(ct.Target)
       and ct.CanCast(204019) and select(1, GetSpellCharges(204019)) == 3
       and ct.IsInRange(ct.player, ct.Target, 8) then
-          return ct.AddSpellToQueue(204019)
+          return CastSpellByID(204019)
       end
     end
   end
@@ -156,19 +156,20 @@ function ct.PaladinProtectionTaunt(unit)
   -- Hand of Reckoning
   if ct.CanCast(62124, unit) and ct.UnitIsHostile(unit) and ct.IsInLOS(unit)
   and ct.IsInRange(ct.player, unit, 25) then
+    -- Here it is necessary to let the queue cast the spell
     return ct.AddSpellToQueue(62124, unit)
   end
 
   -- Avenger's Shield
   if ct.UnitIsHostile(unit) and ct.IsInLOS(unit)
   and ct.CanCast(31935, unit) and ct.IsFacing(unit, ct.CastAngle) then
-    return ct.AddSpellToQueue(31935, unit)
+    return CastSpellByID(31935, unit)
   end
 
   -- Judgment
   if ct.UnitIsHostile(unit) and ct.IsInLOS(unit)
   and ct.CanCast(20271, unit) and ct.IsFacing(unit, ct.CastAngle) then
-    return ct.AddSpellToQueue(20271, unit)
+    return CastSpellByID(20271, unit)
   end
 end
 
@@ -177,18 +178,18 @@ function ct.PaladinProtectionInterrupt(unit)
 
   -- Rebuke
   if ct.CanCast(96231, unit) and ct.IsInLOS(unit) then
-    return ct.AddSpellToQueue(96231)
+    return CastSpellByID(96231, unit)
   end
 
   -- Blinding Light
   if ct.CanCast(115750) and ct.IsInLOS(unit) and ct.IsInRange(ct.player, unit, 10) then
-    return ct.AddSpellToQueue(115750)
+    return CastSpellByID(115750, unit)
   end
 
   -- Hammer of Justice
   -- TODO: fix using this on bosses
   if ct.CanCast(853, unit) and ct.IsInLOS(unit) then
-    return ct.AddSpellToQueue(853)
+    return CastSpellByID(853, unit)
   end
 end
 

--- a/Rotations/Paladin - Protection.lua
+++ b/Rotations/Paladin - Protection.lua
@@ -177,20 +177,17 @@ function ct.PaladinProtectionInterrupt(unit)
 
   -- Rebuke
   if ct.CanCast(96231, unit) and ct.IsInLOS(unit) then
-    print("Interrupted with Rebuke")
     return ct.AddSpellToQueue(96231)
   end
 
   -- Blinding Light
   if ct.CanCast(115750) and ct.IsInLOS(unit) and ct.IsInRange(ct.player, unit, 10) then
-    print("Interrupted with Blinding Light")
     return ct.AddSpellToQueue(115750)
   end
 
   -- Hammer of Justice
-  if ct.CanCast(853, unit) and ct.IsInLOS(unit)
-  and UnitClassification(Unit) ~= "elite" and UnitClassification(Unit) ~= "worldboss" then
-    print("Interrupted with Hammer of Justice (Stun)")
+  -- TODO: fix using this on bosses
+  if ct.CanCast(853, unit) and ct.IsInLOS(unit) then
     return ct.AddSpellToQueue(853)
   end
 end


### PR DESCRIPTION
changed the way how the spell manager is called. Instant spells are now cast from within the rotation rather than by the spell manager. Use the spell manager for casted and channelled spells only.